### PR TITLE
Implied Operating hours

### DIFF
--- a/src/hillmaker/plotting.py
+++ b/src/hillmaker/plotting.py
@@ -497,13 +497,13 @@ def make_daily_hill_plot(summary_df: pd.DataFrame, day_of_week: str, metric: str
         x-axis label, default='Hour'
     ylabel : str, optional
         y-axis label, default='Patients'
-    suptitle : str, optional
+    main_title : str, optional
         super title for plot, default = 'Occupancy by time of day and day of week - {scenario_name}'
-    suptitle_properties : None or dict, optional
+    main_title_properties : None or dict, optional
         Dict of `suptitle` properties, default={{'loc': 'left', 'fontsize': 16}}  
-    title : str, optional
+    subtitle : str, optional
         title for plot, default = 'All categories'
-    title_properties : None or dict, optional
+    subtitle_properties : None or dict, optional
         Dict of `title` properties, default={{'loc': 'left', 'style': 'italic'}}
     legend_properties : None or dict, optional
         Dict of `legend` properties, default={{'loc': 'best', 'frameon': True, 'facecolor': 'w'}}
@@ -557,7 +557,8 @@ def make_daily_hill_plot(summary_df: pd.DataFrame, day_of_week: str, metric: str
         # Add data to the plot
         # Mean occupancy as bars - here's the GOTCHA involving the bar width
         bar_width = 1 / (1440 / bin_size_minutes)
-        ax1.bar(timestamps, occ_summary_df_plot['mean'], label=f'Mean {metric}', width=bar_width, color=bar_color_mean)
+        ax1.bar(timestamps, occ_summary_df_plot['mean'], label=f'Mean {metric}',
+                width=bar_width, color=bar_color_mean, edgecolor=bar_color_mean)
 
         # Percentiles as lines
         # Style the line for the occupancy percentile

--- a/src/hillmaker/scenario.py
+++ b/src/hillmaker/scenario.py
@@ -11,6 +11,7 @@ from pydantic import BaseModel, field_validator, model_validator, confloat, Fiel
 # import hillmaker as hm
 from hillmaker.hills import compute_hills_stats, _make_hills, get_plot, get_summary_df, get_bydatetime_df
 from hillmaker.plotting import make_week_hill_plot, make_daily_hill_plot
+from hillmaker.summarize import implied_operating_hours
 
 try:
     import tomllib
@@ -508,6 +509,31 @@ class Scenario(BaseModel):
         """
         df = get_bydatetime_df(self.hills, by_category=by_category)
         return df
+
+    def compute_implied_operating_hours(self, statistic: str = 'mean', threshold: float = 0.2):
+        """
+        Infers operating hours of underlying data.
+
+        Computes implied operating hours based on exceeding a percentage of the
+        maximum occupancy for a given statistic.
+
+        Parameters
+        ----------
+        statistic : str
+            Column name for the statistic value. Default is 'mean'.
+
+        threshold : str
+            Percentage of maximum occupancy that will be considered 'open' for
+            operating purposes, inclusive. Default is 0.2.
+
+        Returns
+        -------
+        pandas styler object
+
+        """
+        occ_df = get_summary_df(self.hills)
+        styler = implied_operating_hours(occ_df, statistic=statistic, threshold=threshold)
+        return styler
 
     def __str__(self):
         """Pretty string representation of a scenario"""


### PR DESCRIPTION
Added a function to compute the implied operating hours, verbosely and aptly named `compute_implied_operating_hours`. 

The thought was to only consider occupancy as a gauge of whether the unit is open or not, since arrivals can stop but the unit may still be occupied. Then again, looking at arrivals and/or departures might be more representative since units effectively "close" themselves off to admits and discharges after a certain hour.

Also need to consider implementation with multiple `cat_field`s, but wanted to get the basics down for your thoughts.

Messed around with styling the df as well. Thought it might be value add to turn two of the columns of the output table into a heatmap.