### PR TITLE
docs: add badges to readme

### DIFF
--- a/.github/workflows/develop-test.yml
+++ b/.github/workflows/develop-test.yml
@@ -1,7 +1,7 @@
 # This workflow will install Python dependencies, run tests and lint with a single version of Python
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
 
-name: Python application
+name: Pytest
 
 on:
   push:

--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+[![github actions docs](https://github.com/misken/hillmaker/actions/workflows/documentation.yml/badge.svg)](https://hillmaker.readthedocs.io/en/latest/intro.html)
+[![github actions pytest](https://github.com/misken/hillmaker/actions/workflows/develop-test.yml/badge.svg)](https://github.com/misken/hillmaker/actions)
+[![python versions](https://img.shields.io/pypi/pyversions/hillmaker)](https://img.shields.io/pypi/pyversions/hillmaker)
+[![PyPI version](https://badge.fury.io/py/hillmaker.svg)](https://pypi.org/project/hillmaker/)
+[![status](https://joss.theoj.org/papers/cd579f0843aedb47cea2ddc6cd2be666/status.svg)](https://joss.theoj.org/papers/cd579f0843aedb47cea2ddc6cd2be666)
 # hillmaker
 
 


### PR DESCRIPTION
Added some badges to the top of the readme for ease of navigation to the documentation, seeing the status of CI, and for providing links to pypi and the JOSS paper. 

For the documentation badge to work, a new workflow should be created that builds the docs (see #73). 

openjournals/joss-reviews#6154